### PR TITLE
Add configuration to hide or show New Tab button

### DIFF
--- a/chrome/includes/cascade-config.css
+++ b/chrome/includes/cascade-config.css
@@ -143,6 +143,12 @@
    *  hide: none
    */ --uc-show-all-tabs-button: none;
 
+  /*  Hide the new Tab button from the Tab Bar
+   *  possible values:
+   *  show: -moz-box
+   *  hide: none
+   */ --uc-show-new-tab-button: -moz-box;
+
 
   /*  Left and Right "dip" of the container indicator
    *  0px equals tab width

--- a/chrome/includes/cascade-tabs.css
+++ b/chrome/includes/cascade-tabs.css
@@ -8,6 +8,10 @@
 #alltabs-button { display: var(--uc-show-all-tabs-button) !important; }
 
 
+/* Hides the new-tab button*/
+#tabs-newtab-button { display: var(--uc-show-new-tab-button) !important; }
+
+
 /* remove tab shadow */
 .tabbrowser-tab
   >.tab-stack


### PR DESCRIPTION
This adds a new configuration option to either show or hide the New Tab button, based on the configuration for the All Tabs button.
Also adds a line in the default `cascade-config.css` to show people how to configure it, same as the All Tabs button.