### PR TITLE
fix navbar color

### DIFF
--- a/chrome/includes/cascade-nav-bar.css
+++ b/chrome/includes/cascade-nav-bar.css
@@ -1,4 +1,4 @@
-#navigator-toolbox:not(:-moz-lwtheme) { background: var(--toolbar-field-background-color) !important; ) }
+#navigator-toolbox { background: var(--toolbar-field-background-color) !important; }
 
 
 


### PR DESCRIPTION
On Linux with Firefox version 129.0.2, the navigation bar is not properly colored with the --uc-base-color. To fix this I removed ":not(:-moz-lwtheme)" from the first line of cascade-nav-bar.css. 

### Before:
![before](https://github.com/user-attachments/assets/7e4af287-f892-4d14-b9a1-8cca48bd334f)
### After:
![after](https://github.com/user-attachments/assets/cfc93e09-8f32-499d-a36e-a56c36df94da)
