### PR TITLE
feat: oneline breakpoint config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ If you'd like to have Cascade transition into it's Oneline layout on either smal
 ```css
 /*  The point at which the URL Bar switches to the
  *  Oneline layout
- */ --urlbar-breakpoint: 1000px;
+ */ --uc-urlbar-breakpoint: 1000px;
 ```
 
 <br><br><br>

--- a/chrome/includes/cascade-config-mouse.css
+++ b/chrome/includes/cascade-config-mouse.css
@@ -81,7 +81,7 @@
 
   /*  The point at which the URL Bar switches to the
    *  Oneline layout
-   */ --urlbar-breakpoint: 1000px;
+   */ --uc-urlbar-breakpoint: 1000px;
 
 }
 

--- a/chrome/includes/cascade-config.css
+++ b/chrome/includes/cascade-config.css
@@ -80,7 +80,7 @@
 
   /*  The point at which the URL Bar switches to the
    *  Oneline layout
-   */ --urlbar-breakpoint: 1000px;
+   */ --uc-urlbar-breakpoint: 1000px;
 
   /*  Firefox can be a little wonky with the vertical
    *  URL Bar placement. Change this variable to adapt

--- a/chrome/includes/cascade-responsive-windows-fix.css
+++ b/chrome/includes/cascade-responsive-windows-fix.css
@@ -1,4 +1,4 @@
-@media (min-width: var(--urlbar-breakpoint)) {
+@media (min-width: var(--uc-urlbar-breakpoint)) {
 
   #nav-bar { margin: calc((var(--urlbar-min-height) * -1) - 12px) calc(100vw - var(--uc-urlbar-min-width)) 0 0 !important; }
   #titlebar { margin-inline-start: var(--uc-urlbar-min-width) !important; }

--- a/chrome/includes/cascade-responsive.css
+++ b/chrome/includes/cascade-responsive.css
@@ -1,4 +1,4 @@
-@media (min-width: var(--urlbar-breakpoint)) {
+@media (min-width: var(--uc-urlbar-breakpoint)) {
 
 
   #navigator-toolbox { display: flex; flex-wrap: wrap; flex-direction: row; }


### PR DESCRIPTION
Moves the oneline breakpoint configuration to a variable. This is useful for people who want to use the default css provided by this repo and override some css variables - rather than having to maintain an up-to-date version with different css.

Eg. my situation using nix:
```nix
      userChrome = ''
        @import '${inputs.firefox-cascade}/chrome/includes/cascade-config-mouse.css';
        @import '${inputs.firefox-cascade}/integrations/catppuccin/cascade-macchiato.css';

        @import '${inputs.firefox-cascade}/chrome/includes/cascade-layout.css';
        @import '${inputs.firefox-cascade}/chrome/includes/cascade-responsive.css';
        @import '${inputs.firefox-cascade}/chrome/includes/cascade-floating-panel.css';

        @import '${inputs.firefox-cascade}/chrome/includes/cascade-nav-bar.css';
        @import '${inputs.firefox-cascade}/chrome/includes/cascade-tabs.css';

        :root {
          --uc-toolbar-position: 4;
          --uc-border-radius: 12px;
          --uc-accent-colour: var(--uc-identity-colour-pink);
          --uc-urlbar-breakpoint: 1800px;
        }
      '';
```