### PR TITLE
fix: patch tcr extension styling for firefox >= 132.0

### DIFF
--- a/integrations/tabcenter-reborn/cascade-tcr.css
+++ b/integrations/tabcenter-reborn/cascade-tcr.css
@@ -29,8 +29,8 @@
 
 [sidebarcommand*="tabcenter"] #sidebar { height: 100%; max-height: 100%; }
 
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #appcontent { margin-left: 50px; }
-#main-window[inFullscreen][inDOMFullscreen] #appcontent { margin-left: 0; }
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #tabbrowser-tabbox { margin-left: 50px; }
+#main-window[inFullscreen][inDOMFullscreen] #tabbrowser-tabbox { margin-left: 0; }
 /* Removes gap between active tab highlight and edge of bar */
 #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] #sidebar-header, #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] ~ #sidebar-splitter {
     display: none;

--- a/integrations/tabcenter-reborn/cascade-tcr.css
+++ b/integrations/tabcenter-reborn/cascade-tcr.css
@@ -12,7 +12,7 @@
 
   position: absolute;
   top: 0; bottom: 0;
-  z-index: 1;
+  z-index: 3;
 
   min-width: 50px !important; max-width: 50px !important;
 

--- a/integrations/tabcenter-reborn/cascade-tcr.css
+++ b/integrations/tabcenter-reborn/cascade-tcr.css
@@ -29,7 +29,7 @@
 
 [sidebarcommand*="tabcenter"] #sidebar { height: 100%; max-height: 100%; }
 
-#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #tabbrowser-tabbox { margin-left: 50px; }
+#sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #tabbrowser-tabbox { margin-left: 50px !important; }
 #main-window[inFullscreen][inDOMFullscreen] #tabbrowser-tabbox { margin-left: 0; }
 /* Removes gap between active tab highlight and edge of bar */
 #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] #sidebar-header, #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] ~ #sidebar-splitter {

--- a/integrations/tabcenter-reborn/cascade-tcr.css
+++ b/integrations/tabcenter-reborn/cascade-tcr.css
@@ -30,7 +30,7 @@
 [sidebarcommand*="tabcenter"] #sidebar { height: 100%; max-height: 100%; }
 
 #sidebar-box[sidebarcommand*="tabcenter"]:not([hidden]) ~ #tabbrowser-tabbox { margin-left: 50px !important; }
-#main-window[inFullscreen][inDOMFullscreen] #tabbrowser-tabbox { margin-left: 0; }
+#main-window[inFullscreen][inDOMFullscreen] #tabbrowser-tabbox { margin-left: 0 !important; }
 /* Removes gap between active tab highlight and edge of bar */
 #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] #sidebar-header, #sidebar-box[sidebarcommand="tabcenter-reborn_ariasuni-sidebar-action"] ~ #sidebar-splitter {
     display: none;


### PR DESCRIPTION
Fixes a non-opened issue where the tabcenter-reborn extension overlapped the browser content when not hovered on due to an id change on the main content tabbox from `#appcontent` to `#tabbrowser-tabbox` in recent firefox versions (at least >= 132.0).

Also fixes a z-ordering change that broke hover functionnality since version 133.0.

## Proposed Changes
  - change `#appcontent` to `#tabbrowser-tabbox` in `cascade-tcr.css`
  - change sidebar-box's `z-index` from 1 to 3 in `cascade-tcr.css`